### PR TITLE
WIP: Add create-program-address instruction to cli utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,6 +3559,7 @@ dependencies = [
  "criterion-stats",
  "ctrlc",
  "dirs",
+ "hex",
  "humantime 2.0.1",
  "indicatif",
  "log 0.4.8",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,6 +23,7 @@ indicatif = "0.15.0"
 humantime = "2.0.1"
 num-traits = "0.2"
 pretty-hex = "0.1.1"
+hex = "0.4.2"
 reqwest = { version = "0.10.8", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 serde = "1.0.112"
 serde_derive = "1.0.103"

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -95,6 +95,10 @@ pub enum CliCommand {
         seed: String,
         program_id: Pubkey,
     },
+    CreateProgramAddress {
+        seed: String,
+        program_id: Pubkey,
+    },
     Feature(FeatureCliCommand),
     Inflation(InflationCliCommand),
     Fees,
@@ -540,6 +544,9 @@ pub fn parse_command(
         ("create-address-with-seed", Some(matches)) => {
             parse_create_address_with_seed(matches, default_signer, wallet_manager)
         }
+        ("create-program-address", Some(matches)) => {
+            parse_create_program_address(matches)
+        }
         ("feature", Some(matches)) => {
             parse_feature_subcommand(matches, default_signer, wallet_manager)
         }
@@ -880,6 +887,50 @@ fn process_create_address_with_seed(
     };
     let address = Pubkey::create_with_seed(&from_pubkey, seed, program_id)?;
     Ok(address.to_string())
+}
+
+pub fn parse_create_program_address(
+    matches: &ArgMatches<'_>,
+) -> Result<CliCommandInfo, CliError> {
+    let signers = vec![];
+
+    let program_id = match matches.value_of("program_id").unwrap() {
+        "NONCE" => system_program::id(),
+        "STAKE" => solana_stake_program::id(),
+        "VOTE" => solana_vote_program::id(),
+        _ => pubkey_of(matches, "program_id").unwrap(),
+    };
+
+    let seed = matches.value_of("seed").unwrap().to_string();
+
+//    if seed.len() > MAX_SEED_LEN {
+//        return Err(CliError::BadParameter(
+//            "Address seed must not be longer than 32 bytes".to_string(),
+//        ));
+//    }
+
+    Ok(CliCommandInfo {
+        command: CliCommand::CreateProgramAddress {
+            seed,
+            program_id,
+        },
+        signers,
+    })
+}
+
+fn process_create_program_address(
+    seed: &str,
+    program_id: &Pubkey,
+) -> ProcessResult {
+    let strings = seed.split_whitespace().collect::<Vec<_>>();
+    let mut seeds = vec![];
+    let mut seeds_vec = vec![];
+    for s in strings {
+        seeds_vec.push(hex::decode(s).unwrap());
+    }
+    for i in &seeds_vec {seeds.push(&i[..]);}
+    let (address,nonce) = Pubkey::find_program_address(&seeds, program_id);
+    Ok(address.to_string() + "  " + &nonce.to_string())
 }
 
 fn process_airdrop(
@@ -1438,6 +1489,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             seed,
             program_id,
         } => process_create_address_with_seed(config, from_pubkey.as_ref(), &seed, &program_id),
+        CliCommand::CreateProgramAddress {seed, program_id,} => {
+            process_create_program_address(&seed, &program_id)
+        }
         CliCommand::Fees => process_fees(&rpc_client, config),
         CliCommand::Feature(feature_subcommand) => {
             process_feature_subcommand(&rpc_client, config, feature_subcommand)
@@ -2176,6 +2230,28 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("FROM_PUBKEY")
                         .required(false),
                         "From (base) key, [default: cli config keypair]. "),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("create-program-address")
+                .about("Generate a program address")
+                .arg(
+                    Arg::with_name("seed")
+                        .index(1)
+                        .value_name("SEED_STRING")
+                        .takes_value(true)
+                        .required(true)
+                        .help("The seeds (a string containing seeds in hex form, separated by spaces)"),
+                )
+                .arg(
+                    Arg::with_name("program_id")
+                        .index(2)
+                        .value_name("PROGRAM_ID")
+                        .takes_value(true)
+                        .required(true)
+                        .help(
+                            "The program_id that the address will ultimately be used for"
+                        ),
                 ),
         )
         .subcommand(


### PR DESCRIPTION
#### Problem
User can't create program address for specified program_id and seeds. This functionality available for rust-program.

#### Summary of Changes
Add `create-program-address <seeds in hex> <program_id>` command to CLI.

